### PR TITLE
Deprecated youtube path within Kodi

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.creationtoday_org" version="1.0.1" name="Creation Today" provider-name="Romans I XVI">
+<addon id="plugin.video.creationtoday_org" version="1.0.2" name="Creation Today" provider-name="Romans I XVI">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
-        <import addon="script.module.urlresolver" version="2.1.2"/>
 	<import addon="script.module.t0mm0.common" version="2.1.0"/>
 	<import addon="script.module.beautifulsoup4" version="4.3.1"/>
     </requires>
@@ -11,8 +10,8 @@
     </extension>
     <extension point="xbmc.addon.metadata">
 	<language />
-        <summary>Creation Today</summary>
-        <description>Creation Today is a leading Christian-apologetics ministry, defending the literal interpretation of the Genesis creation account from the theory of evolution.[CR][CR]This add-on gives access to all of the videos available on creationtoday.org. [CR][CR]The Creation Today Show, Creation Minute, Creation Bytes, and Kent Hovind's seminars and debates.</description>
+        <summary lang="en">Creation Today</summary>
+        <description lang="en">Creation Today is a leading Christian-apologetics ministry, defending the literal interpretation of the Genesis creation account from the theory of evolution.[CR][CR]This add-on gives access to all of the videos available on creationtoday.org. [CR][CR]The Creation Today Show, Creation Minute, Creation Bytes, and Kent Hovind's seminars and debates.</description>
         <platform>all</platform>
         <license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
         <forum>http://forum.xbmc.org/showthread.php?tid=183376</forum>

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,3 +2,5 @@ Version 1.0.0
 - Initial version
 Version 1.0.1
 - Fixed breakage caused by website changes.
+Version 1.0.2
+- Update resolution of youtube urls

--- a/default.py
+++ b/default.py
@@ -8,7 +8,6 @@ import re
 import sys
 from t0mm0.common.addon import Addon
 from t0mm0.common.net import Net
-import urlresolver
 from bs4 import BeautifulSoup
 
 
@@ -112,15 +111,21 @@ def ADDLINKS_Featured():
 	addon.add_video_item({'url': 'http://www.youtube.com/watch?v=U0u3-2CGOMQ'},{'title': 'Evolution Vs. God'},img='http://img.youtube.com/vi/U0u3-2CGOMQ/0.jpg',fanart=fanart)
 	addon.add_video_item({'url': 'http://www.youtube.com/watch?v=7y2KsU_dhwI'},{'title': '180 Movie'},img='http://img.youtube.com/vi/7y2KsU_dhwI/0.jpg',fanart=fanart)
 
+##################################################################################################################################
 
+def resolve_youtube_url(url):
+	url_patterns = ['(?:youtu.be/|/embed/|/v/|v=)(?P<video_id>[a-zA-Z0-9_\-]{11})']
+	for pattern in url_patterns:
+		v_id = re.search(pattern, url)
+		if v_id:
+			return 'plugin://plugin.video.youtube/play/?video_id={}'.format(v_id.group('video_id'))
+	return ''
 
 
 if play:
 	url = addon.queries.get('url', '')
-	host = addon.queries.get('host', '')
-	media_id = addon.queries.get('media_id', '')
-	stream_url = urlresolver.HostedMediaFile(url=url, host=host, media_id=media_id).resolve()
-	addon.resolve_url(stream_url)
+	playable_url = resolve_youtube_url(url)
+	addon.resolve_url(playable_url)
 
 ##################################################################################################################################
 
@@ -133,6 +138,7 @@ def getUrl(url):
 	return link
 
 ##################################################################################################################################
+
 
 def get_params():
         param=[]


### PR DESCRIPTION
Hey @Romans-I-XVI 

This plugin has not been updated in a while and as of now the urls you are sending to the kodi player are deprecated:

```
22:43:43 T:139889794426624 WARNING: [plugin.video.youtube] DEPRECATED "plugin://plugin.video.youtube/?action=play_video&videoid=ID"
22:43:43 T:139889794426624 WARNING: [plugin.video.youtube] USE INSTEAD "plugin://plugin.video.youtube/play/?video_id=ID"
```

This pull request fixes it. I can also take care of the update on the official repository.

Thanks